### PR TITLE
Fix double-free when removing lock popup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -403,6 +403,7 @@ list(APPEND SOURCE_FILES
         displayapp/widgets/PageIndicator.cpp
         displayapp/widgets/DotIndicator.cpp
         displayapp/widgets/StatusIcons.cpp
+        displayapp/widgets/PopupMessage.cpp
 
         ## Settings
         displayapp/screens/settings/QuickSettings.cpp

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -476,6 +476,12 @@ void DisplayApp::Refresh() {
         LoadNewScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
         motorController.RunForDuration(35);
         break;
+      case Messages::ShowIgnoreTouchPopup:
+        popupMessage.SetHidden(false);
+        break;
+      case Messages::HideIgnoreTouchPopup:
+        popupMessage.SetHidden(true);
+        break;
     }
   }
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -505,6 +505,11 @@ void DisplayApp::LoadNewScreen(Apps app, DisplayApp::FullRefreshDirections direc
   // This is mainly to fix an issue with receiving two notifications at the same time
   // and shouldn't happen otherwise.
   if (app != currentApp) {
+    // We need to remove the popup
+    // If we keep the popup linked to the previous view, and this view is deleted, a bug will occur if we try to re-remove the popup.
+    // Not removing the popup will also prevent the popup to be raised on top of
+    // the new app
+    popupMessage.SetHidden(true);
     returnAppStack.Push(currentApp);
     appStackDirections.Push(direction);
   }

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -15,6 +15,7 @@
 #include "components/timer/Timer.h"
 #include "components/alarm/AlarmController.h"
 #include "touchhandler/TouchHandler.h"
+#include "displayapp/widgets/PopupMessage.h"
 
 #include "displayapp/Messages.h"
 #include "BootErrors.h"
@@ -102,6 +103,7 @@ namespace Pinetime {
       Pinetime::Controllers::FirmwareValidator validator;
       Pinetime::Components::LittleVgl lvgl;
       Pinetime::Controllers::Timer timer;
+      Pinetime::Applications::Widgets::PopupMessage popupMessage;
 
       AppControllers controllers;
       TaskHandle_t taskHandle;

--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -24,6 +24,8 @@ namespace Pinetime {
         AlarmTriggered,
         Chime,
         BleRadioEnableToggle,
+        ShowIgnoreTouchPopup,
+        HideIgnoreTouchPopup
       };
     }
   }

--- a/src/displayapp/widgets/PopupMessage.cpp
+++ b/src/displayapp/widgets/PopupMessage.cpp
@@ -1,0 +1,56 @@
+#include "displayapp/widgets/PopupMessage.h"
+#include "displayapp/InfiniTimeTheme.h"
+#include <libraries/log/nrf_log.h>
+
+using namespace Pinetime::Applications::Widgets;
+
+PopupMessage::PopupMessage() {
+}
+
+void PopupMessage::Create() {
+  popup = lv_obj_create(lv_scr_act(), nullptr);
+  lv_obj_set_size(popup, 90, 90);
+  lv_obj_align(popup, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+  lv_obj_set_style_local_bg_color(popup, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, Colors::bg);
+  lv_obj_set_style_local_bg_opa(popup, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_60);
+  lv_obj_t* lockBody = lv_obj_create(popup, nullptr);
+  lv_obj_set_size(lockBody, 55, 50);
+  lv_obj_align(lockBody, popup, LV_ALIGN_CENTER, 0, 10);
+
+  lv_obj_set_style_local_bg_color(lockBody, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_opa(lockBody, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_border_color(lockBody, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_border_width(lockBody, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 22);
+  lv_obj_set_style_local_border_side(lockBody, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_BORDER_SIDE_FULL);
+  lv_obj_set_style_local_border_opa(lockBody, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_100);
+
+  lv_obj_t* lockTop = lv_obj_create(popup, nullptr);
+  lv_obj_set_size(lockTop, 30, 35);
+  lv_obj_align(lockTop, popup, LV_ALIGN_CENTER, 0, -20);
+  lv_obj_set_style_local_bg_color(lockTop, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_opa(lockTop, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_border_color(lockTop, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_border_width(lockTop, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 6);
+  lv_obj_set_style_local_border_side(lockTop, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_BORDER_SIDE_FULL);
+  lv_obj_set_style_local_border_opa(lockTop, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_100);
+
+  lv_obj_set_hidden(popup, isHidden);
+}
+
+void PopupMessage::SetHidden(bool hidden) {
+  if (isHidden == hidden) {
+    return;
+  }
+  isHidden = hidden;
+  // create/delete on demand
+  if (popup == nullptr && !isHidden) {
+    Create();
+  } else if (popup != nullptr) {
+    lv_obj_del(popup);
+    popup = nullptr;
+  }
+}
+
+bool PopupMessage::IsHidden() {
+  return isHidden;
+}

--- a/src/displayapp/widgets/PopupMessage.cpp
+++ b/src/displayapp/widgets/PopupMessage.cpp
@@ -4,9 +4,6 @@
 
 using namespace Pinetime::Applications::Widgets;
 
-PopupMessage::PopupMessage() {
-}
-
 void PopupMessage::Create() {
   popup = lv_obj_create(lv_scr_act(), nullptr);
   lv_obj_set_size(popup, 90, 90);
@@ -37,7 +34,7 @@ void PopupMessage::Create() {
   lv_obj_set_hidden(popup, isHidden);
 }
 
-void PopupMessage::SetHidden(bool hidden) {
+void PopupMessage::SetHidden(const bool hidden) {
   if (isHidden == hidden) {
     return;
   }
@@ -51,6 +48,6 @@ void PopupMessage::SetHidden(bool hidden) {
   }
 }
 
-bool PopupMessage::IsHidden() {
+bool PopupMessage::IsHidden() const {
   return isHidden;
 }

--- a/src/displayapp/widgets/PopupMessage.h
+++ b/src/displayapp/widgets/PopupMessage.h
@@ -1,20 +1,16 @@
 #pragma once
 #include <lvgl/lvgl.h>
 
-namespace Pinetime {
-  namespace Applications {
-    namespace Widgets {
-      class PopupMessage {
-      public:
-        PopupMessage();
-        void Create();
-        void SetHidden(bool hidden);
-        bool IsHidden();
+namespace Pinetime::Applications::Widgets {
+  class PopupMessage {
+  public:
+    PopupMessage() = default;
+    void Create();
+    void SetHidden(bool hidden);
+    bool IsHidden() const;
 
-      private:
-        lv_obj_t* popup = nullptr;
-        bool isHidden = true;
-      };
-    }
-  }
+  private:
+    lv_obj_t* popup = nullptr;
+    bool isHidden = true;
+  };
 }

--- a/src/displayapp/widgets/PopupMessage.h
+++ b/src/displayapp/widgets/PopupMessage.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <lvgl/lvgl.h>
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Widgets {
+      class PopupMessage {
+      public:
+        PopupMessage();
+        void Create();
+        void SetHidden(bool hidden);
+        bool IsHidden();
+
+      private:
+        lv_obj_t* popup = nullptr;
+        bool isHidden = true;
+      };
+    }
+  }
+}

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -215,7 +215,7 @@ void SystemTask::Work() {
           }
           break;
         case Messages::SetOffAlarm:
-          unlockedByButton = true;  // unlock so it is possible to press red stop button
+          unlockedByButton = true; // unlock so it is possible to press red stop button
           GoToRunning();
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::AlarmTriggered);
           break;
@@ -225,7 +225,7 @@ void SystemTask::Work() {
           bleDiscoveryTimer = 5;
           break;
         case Messages::BleFirmwareUpdateStarted:
-          unlockedByButton = true;  // prevent no screen-locked popup on firmware update
+          unlockedByButton = true; // prevent no screen-locked popup on firmware update
           GoToRunning();
           wakeLocksHeld++;
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::BleFirmwareUpdateStarted);

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -134,6 +134,8 @@ namespace Pinetime {
       bool stepCounterMustBeReset = false;
       static constexpr TickType_t batteryMeasurementPeriod = pdMS_TO_TICKS(10 * 60 * 1000);
 
+      bool unlockedByButton = true;
+
       SystemMonitor monitor;
     };
   }


### PR DESCRIPTION
When the popup is created on the notifications view, and the user return to the watch face; The popup is deleted and freed, but `popup` wasn't not set to `nullptr`, and `isHidden` to false so we ended up deleting again the popup. The best way to handle that is to always remove the popup when changing app. If the user click again, a new popup will show